### PR TITLE
Update Ant version to 1.10.8

### DIFF
--- a/ant/build.gradle
+++ b/ant/build.gradle
@@ -8,7 +8,7 @@ if (System.getProperty('os.name', '').toLowerCase().contains('windows')) {
 }
 
 
-final String antVersion = "1.10.7"
+final String antVersion = "1.10.8"
 final String antURL = "https://www.apache.org/dist/ant/binaries/apache-ant-$antVersion-bin.zip"
 final File antHome = new File(buildDir, "ant-home")
 final File antZip = new File(buildDir, "apache-ant-$antVersion-bin.zip")


### PR DESCRIPTION
`1.10.7` – dropped 😞

https://downloads.apache.org/ant/binaries/

![Screenshot 2020-06-02 at 12 46 27](https://user-images.githubusercontent.com/242514/83505880-170af100-a4cf-11ea-8212-5ff5afc7dd7d.png)
